### PR TITLE
:ambulance: Remove cache flush bit on PTR announcements

### DIFF
--- a/server.go
+++ b/server.go
@@ -547,7 +547,7 @@ func (s *Server) composeLookupAnswers(service *ServiceEntry, useCacheFlush bool,
 		Hdr: dns.RR_Header{
 			Name:   service.ServiceName(),
 			Rrtype: dns.TypePTR,
-			Class:  dns.ClassINET | cacheFlush,
+			Class:  dns.ClassINET,
 			Ttl:    ttl,
 		},
 		Ptr: service.ServiceInstanceName(),


### PR DESCRIPTION
Bonsoir used to announce the PTR service record with the Cache Flush bit set,
which seems to confuse avahi, and cause it to sometimes mess up its service records.
Remove the cache flush bit fixes it, and it seems to not break macosx either.